### PR TITLE
Add unit tests to reach 80% code coverage

### DIFF
--- a/CS/AspNetWebFormsDataFederation.Tests/DefaultTests.cs
+++ b/CS/AspNetWebFormsDataFederation.Tests/DefaultTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Web.Hosting;
+using DevExpress.DashboardCommon;
+using DevExpress.DashboardWeb;
+using DevExpress.DataAccess.DataFederation;
+using DevExpress.DataAccess.Excel;
+using DevExpress.DataAccess.Json;
+using DevExpress.DataAccess.Sql;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AspNetWebFormsDataFederation.Tests
+{
+    [TestClass]
+    public class DefaultTests
+    {
+        private Default _defaultPage;
+        private Mock<ASPxDashboard> _mockDashboard;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _defaultPage = new Default();
+            _mockDashboard = new Mock<ASPxDashboard>();
+            _defaultPage.ASPxDashboard1 = _mockDashboard.Object;
+        }
+
+        [TestMethod]
+        public void Page_Load_SetsDashboardStorage()
+        {
+            _defaultPage.Page_Load(null, EventArgs.Empty);
+
+            _mockDashboard.Verify(d => d.SetDashboardStorage(It.IsAny<DashboardFileStorage>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void ASPxDashboard1_ConfigureDataConnection_SetsExcelConnectionParameters()
+        {
+            var mockEventArgs = new Mock<ConfigureDataConnectionWebEventArgs>("excelSales", new ExcelDataSourceConnectionParameters());
+            _defaultPage.ASPxDashboard1_ConfigureDataConnection(null, mockEventArgs.Object);
+
+            var excelParams = mockEventArgs.Object.ConnectionParameters as ExcelDataSourceConnectionParameters;
+            Assert.IsNotNull(excelParams);
+            Assert.AreEqual(HostingEnvironment.MapPath(@"~/App_Data/SalesPerson.xlsx"), excelParams.FileName);
+        }
+
+        [TestMethod]
+        public void ASPxDashboard1_ConfigureDataConnection_SetsJsonConnectionParameters()
+        {
+            var mockEventArgs = new Mock<ConfigureDataConnectionWebEventArgs>("jsonCategories", new JsonSourceConnectionParameters());
+            _defaultPage.ASPxDashboard1_ConfigureDataConnection(null, mockEventArgs.Object);
+
+            var jsonParams = mockEventArgs.Object.ConnectionParameters as JsonSourceConnectionParameters;
+            Assert.IsNotNull(jsonParams);
+            Assert.AreEqual(HostingEnvironment.MapPath(@"~/App_Data/Categories.json"), ((UriJsonSource)jsonParams.JsonSource).Uri);
+        }
+
+        [TestMethod]
+        public void DataLoading_SetsData()
+        {
+            var mockEventArgs = new Mock<DataLoadingWebEventArgs>("odsInvoices");
+            _defaultPage.DataLoading(null, mockEventArgs.Object);
+
+            Assert.IsNotNull(mockEventArgs.Object.Data);
+        }
+
+        [TestMethod]
+        public void CreateFederatedDataSource_ReturnsValidDataSource()
+        {
+            var sqlDataSource = new DashboardSqlDataSource("SQL Data Source", "NWindConnectionString");
+            var excelDataSource = new DashboardExcelDataSource("Excel Data Source");
+            var objectDataSource = new DashboardObjectDataSource("Object Data Source");
+            var jsonDataSource = new DashboardJsonDataSource("JSON Data Source");
+
+            var result = Default.CreateFederatedDataSource(sqlDataSource, excelDataSource, objectDataSource, jsonDataSource);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Federated Data Source", result.Name);
+        }
+    }
+}

--- a/CS/AspNetWebFormsDataFederation.Tests/InvoicesTests.cs
+++ b/CS/AspNetWebFormsDataFederation.Tests/InvoicesTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AspNetWebFormsDataFederation;
+
+namespace AspNetWebFormsDataFederation.Tests
+{
+    [TestClass]
+    public class InvoicesTests
+    {
+        [TestMethod]
+        public void CreateData_ReturnsExpectedData()
+        {
+            var data = Invoices.CreateData();
+
+            Assert.IsNotNull(data);
+            Assert.AreEqual(35, data.Count);
+            Assert.AreEqual("Germany", data[0].Country);
+            Assert.AreEqual("Aachen", data[0].City);
+            Assert.AreEqual("Raclette Courdavault", data[0].ProductName);
+            Assert.AreEqual(30, data[0].Quantity);
+            Assert.AreEqual(0, data[0].Discount);
+            Assert.AreEqual(1650, data[0].ExtendedPrice);
+            Assert.AreEqual(149.47, data[0].Freigth);
+            Assert.AreEqual(55, data[0].UnitPrice);
+        }
+
+        [TestMethod]
+        public void GenerateOrderDate_ReturnsValidDate()
+        {
+            var date = typeof(Invoices).GetMethod("GenerateOrderDate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).Invoke(null, null);
+
+            Assert.IsNotNull(date);
+            Assert.IsInstanceOfType(date, typeof(DateTime));
+            var orderDate = (DateTime)date;
+            Assert.IsTrue(orderDate.Year >= DateTime.Today.Year - 3 && orderDate.Year <= DateTime.Today.Year);
+        }
+    }
+}

--- a/CS/AspNetWebFormsDataFederation.Tests/LightMasterTests.cs
+++ b/CS/AspNetWebFormsDataFederation.Tests/LightMasterTests.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AspNetWebFormsDataFederation.Tests
+{
+    [TestClass]
+    public class LightMasterTests
+    {
+        private LightMaster _lightMaster;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _lightMaster = new LightMaster();
+        }
+
+        [TestMethod]
+        public void Page_Load_DoesNotThrowException()
+        {
+            try
+            {
+                _lightMaster.Page_Load(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Page_Load threw an exception: " + ex.Message);
+            }
+        }
+    }
+}

--- a/CS/AspNetWebFormsDataFederation.Tests/MainMasterTests.cs
+++ b/CS/AspNetWebFormsDataFederation.Tests/MainMasterTests.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AspNetWebFormsDataFederation.Tests
+{
+    [TestClass]
+    public class MainMasterTests
+    {
+        private MainMaster _mainMaster;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mainMaster = new MainMaster();
+        }
+
+        [TestMethod]
+        public void Page_Load_DoesNotThrowException()
+        {
+            try
+            {
+                _mainMaster.Page_Load(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Page_Load threw an exception: " + ex.Message);
+            }
+        }
+    }
+}

--- a/CS/AspNetWebFormsDataFederation.Tests/RootMasterTests.cs
+++ b/CS/AspNetWebFormsDataFederation.Tests/RootMasterTests.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AspNetWebFormsDataFederation.Tests
+{
+    [TestClass]
+    public class RootMasterTests
+    {
+        private RootMaster _rootMaster;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _rootMaster = new RootMaster();
+        }
+
+        [TestMethod]
+        public void Page_Load_DoesNotThrowException()
+        {
+            try
+            {
+                _rootMaster.Page_Load(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Page_Load threw an exception: " + ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests to reach 80% code coverage.

* **DefaultTests.cs**
  - Create a test class `DefaultTests`.
  - Write unit tests for `Page_Load`, `ASPxDashboard1_ConfigureDataConnection`, `DataLoading`, and `CreateFederatedDataSource` methods.

* **InvoicesTests.cs**
  - Create a test class `InvoicesTests`.
  - Write unit tests for `CreateData` and `GenerateOrderDate` methods.

* **MainMasterTests.cs**
  - Create a test class `MainMasterTests`.
  - Write unit tests for `Page_Load` method.

* **LightMasterTests.cs**
  - Create a test class `LightMasterTests`.
  - Write unit tests for `Page_Load` method.

* **RootMasterTests.cs**
  - Create a test class `RootMasterTests`.
  - Write unit tests for `Page_Load` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Visma-Tech-Cloud-and-VCDM/aspnet-web-forms-example?shareId=9869f572-8849-48e2-916e-87bfa6204001).